### PR TITLE
Allow all assertion arguments in with-expectations

### DIFF
--- a/expectations.lisp
+++ b/expectations.lisp
@@ -59,7 +59,11 @@ EXPECTATIONS should be lists of one of the following forms.
                                     "Invalid inline expectation received non-symbols: ~{~S~^, ~}"
                                     (remove-if #'symbolp (cdr e))))
                  
-                 ((:assertion) nil)
+                 ((:assertion)
+                  (assert (cdr e)
+                          ()
+                          "Invalid assertion expectation: ~S"
+                          e))
                  
                  ((:or-else)
                   (assert (= 2 (length (cdr e)))

--- a/expectations.lisp
+++ b/expectations.lisp
@@ -21,7 +21,7 @@ EXPECTATIONS should be lists of one of the following forms.
       types indicate multiple values are returned. If the POLICY is
       met, then the assertion will be elided at runtime.
 
-    Assertion Expectation: (ASSERTION <assertion>)
+    Assertion Expectation: (ASSERTION <assertion> [(place*) [datum-form argument-form*]])
 
       Assert that the assertion <assertion> should be true. If the
       POLICY is met, then the assertion will be elided at runtime.
@@ -59,12 +59,7 @@ EXPECTATIONS should be lists of one of the following forms.
                                     "Invalid inline expectation received non-symbols: ~{~S~^, ~}"
                                     (remove-if #'symbolp (cdr e))))
                  
-                 ((:assertion)
-                  (assert (and (cdr e)
-                               (null (cddr e)))
-                          ()
-                          "Invalid assertion expectation: ~S"
-                          e))
+                 ((:assertion) nil)
                  
                  ((:or-else)
                   (assert (= 2 (length (cdr e)))
@@ -81,7 +76,7 @@ EXPECTATIONS should be lists of one of the following forms.
                             (dolist (var vars)
                               (push `(check-type ,var ,type) preamble-forms))))
                  ((:returns) (setq return-types (cdr e)))
-                 ((:assertion) (push `(assert ,(second e)) preamble-forms))
+                 ((:assertion) (push `(assert ,@(cdr e)) preamble-forms))
                  ((:or-else) (push `(unless ,(second e)
                                       ,(third e))
                                    preamble-forms))))


### PR DESCRIPTION
This allows for all `assert` arguments to be passed to `with-expectations`. This will allow for more helpful error messages to be used within `with-expectations`.

The validation for the `assertion` branch was removed because there is no easy way to validate assertion arguments.