### PR TITLE
Use CL-ENVIRONMENTS as fallback for DECLARATION-INFORMATION

### DIFF
--- a/policy-cond.asd
+++ b/policy-cond.asd
@@ -8,11 +8,10 @@
   :author "Robert Smith <quad@symbo1ics.com>"
   :maintainer "Robert Smith <quad@symbo1ics.com>"
   :license "BSD 3-clause (See LICENSE)"
-  :depends-on (
-               #+sbcl sb-cltl2          ; This is a contrib.
+  :depends-on ((:feature :sbcl
+                :sb-cltl2) ; An SBCL contrib enacapsulated via ASDF
                (:feature (:not (:or :sbcl :lispworks :cmucl :ccl :allegro))
-                          :cl-environments)
-               )
+                :cl-environments))
   :serial t
   :components ((:static-file "LICENSE.txt")
                (:file "package")

--- a/policy-cond.asd
+++ b/policy-cond.asd
@@ -10,6 +10,8 @@
   :license "BSD 3-clause (See LICENSE)"
   :depends-on (
                #+sbcl sb-cltl2          ; This is a contrib.
+               (:feature (:not (:or :sbcl :lispworks :cmucl :ccl :allegro))
+                          :cl-environments)
                )
   :serial t
   :components ((:static-file "LICENSE.txt")

--- a/policy-cond.lisp
+++ b/policy-cond.lisp
@@ -23,7 +23,7 @@
     (system:declaration-information symbol env)
 
     #-(or sbcl lispworks cmucl ccl allegro)
-    (error "Declaration information is unavailable for this implementation.")))
+    (cl-environments.cltl2:declaration-information symbol env)))
 
 (defmacro policy (expr env)
   (let ((policy (declaration-information 'optimize env)))


### PR DESCRIPTION
For Lisp implementations that do not provide an implementation of CLtLv2's DECLARATION-INFORMATION, fallback to the portable implementation afforded by CL-ENVIRONMENTS.

This allows POLICY-COND to work with ABCL and ECL.